### PR TITLE
docs(parity): mirror Free checks 28.2 (restraint) + 22.7 (hollow-content)

### DIFF
--- a/cursor-rules/skill-check.mdc
+++ b/cursor-rules/skill-check.mdc
@@ -306,6 +306,22 @@ reason: No concrete format example
 
 **Does NOT fire when** section already uses tables or bullet lists.
 
+### Hollow Content
+
+**Check 22.7-hollow-content** (Suggestion): A gotchas/troubleshooting section with only generic filler and no concrete knowledge is hollow.
+
+**Fires when**: in a `## Gotchas` / `## Troubleshooting` / `## Tips` / `## Caveats` section, 3+ lines are generic filler ("follow team standards", "ensure proper handling", "handle appropriately", "use appropriate methods", "maintain quality") AND no line carries a concrete signal (specific threshold, consequence "X because Y", numbered debug step, or file/function reference).
+
+**Does NOT fire when** the section has at least one concrete threshold, consequence, or debugging step, or the content is in code blocks.
+
+### Restraint Without Safety Carve-Out
+
+**Check 28.2-restraint-without-carveout** (Warning): A restraint/minimalism directive with no validation/security/accessibility carve-out can reward skipping non-negotiables, not just avoiding gold-plating. "Lazy, not negligent."
+
+**Fires when**: a restraint directive is present (YAGNI, "keep it minimal", "don't over-build / over-engineer", "simplest thing that works", "resist the urge to add", "prefer the stdlib") AND no line pairs a keep/never-cut cue ("never cut", "always keep", "still required", "non-negotiable") with a safety noun (validation, security, accessibility / a11y).
+
+**Does NOT fire when**: no restraint directive is present; or an explicit carve-out clause exists. An incidental "security"/"validation" mention without a keep cue is NOT a carve-out.
+
 ---
 
 ## 4. Quality Patterns (Strengths)
@@ -504,6 +520,8 @@ This links to getskillcheck.com when clicked.
 | 9.*-token-* | Tokens | **Pro** | Budget issues |
 | 10.*-enterprise-* | Enterprise | **Pro** | Org deployment issues |
 | 12.*-workflow-* | Workflow | **Pro** | Step-by-step instruction issues |
+| 22.7-hollow-content | Knowledge Density | Free | Hollow gotchas/troubleshooting sections |
+| 28.2-restraint-without-carveout | Restraint | Free | Restraint without a validation/security/a11y carve-out |
 
 ---
 

--- a/skills/skill-check/SKILL.md
+++ b/skills/skill-check/SKILL.md
@@ -478,6 +478,51 @@ description: Generate reports from data. Use when user says "weekly report" or "
 2. Run report generation
 </example>
 
+### Hollow Content
+
+**Check 22.7-hollow-content** (Suggestion): A gotchas/troubleshooting section that contains only generic filler and no concrete knowledge is hollow. It promises hard-won advice but delivers platitudes.
+
+**Detection**: In a `## Gotchas` / `## Troubleshooting` / `## Tips` / `## Caveats` / `## Pitfalls` section, fire when 3+ lines match generic filler ("follow team standards", "ensure proper handling", "handle appropriately", "consider relevant factors", "use appropriate methods", "maintain quality") AND no line carries a concrete knowledge signal (a specific threshold/number-with-unit, a consequence "X because Y", a numbered debugging step, or a file/function reference).
+
+**Exceptions** (not flagged): content inside code blocks; a section that includes at least one concrete threshold, consequence, or debugging step.
+
+<example type="invalid">
+## Gotchas
+
+- Follow team standards for error handling.
+- Ensure proper handling of edge cases.
+- Use appropriate methods and maintain quality.
+
+reason: Generic filler with no concrete knowledge — replace with specific thresholds, consequences, or steps.
+</example>
+
+<example type="valid">
+## Gotchas
+
+- Set retries to 3; the API returns 429 above 10 req/s.
+- If the upload fails, check the auth token first, then the file size limit (50 MB).
+</example>
+
+### Restraint Without Safety Carve-Out
+
+**Check 28.2-restraint-without-carveout** (Warning): If a skill instructs restraint/minimalism but never carves out validation, security, or accessibility, flag it. Restraint without that carve-out can reward skipping non-negotiables, not just avoiding gold-plating. "Lazy, not negligent" is the line.
+
+**Detection**: A restraint/anti-overbuild directive is present (YAGNI, "keep it minimal", "don't over-build / over-engineer", "simplest thing that works", "resist the urge to add", "prefer the stdlib"), AND no line pairs a keep/never-cut cue ("never cut", "always keep", "still required", "non-negotiable") with a safety noun (validation, security, accessibility / a11y). An incidental mention of "security" or "validation" *without* a keep cue does NOT count as a carve-out.
+
+**Does NOT fire when**: no restraint directive is present; or an explicit carve-out clause exists.
+
+**Severity**: Warning
+
+<example type="invalid">
+Keep it minimal. Use the simplest solution that works. Don't gold-plate.
+
+reason: Restraint directive with no validation/security/accessibility carve-out.
+</example>
+
+<example type="valid">
+Prefer the stdlib; resist the urge to add layers. But never skip validation, security, or accessibility. Those are non-negotiable.
+</example>
+
 ---
 
 ## 4. Quality Patterns (Strengths)
@@ -707,6 +752,10 @@ If validation stalls on large files (1000+ lines), break the skill into smaller 
 | 19.1-pattern-detected | Design Pattern Classification | Free |
 | 19.2-19.7 pattern-* | Design Pattern Deep Checks | **Pro** |
 | 20.*-collision-* | Trigger Collision Detection | **Pro** |
+| 22.7-hollow-content | Knowledge Density (hollow) | Free |
+| 22.1-22.6 density-* | Knowledge Density (signals) | **Pro** |
+| 28.2-restraint-without-carveout | Restraint (no carve-out) | Free |
+| 28.1-restraint-with-carveout | Restraint (with carve-out) | **Pro** |
 
 ---
 


### PR DESCRIPTION
Keeps the markdown free tier (Skill + Cursor rule) in parity with the Go free checks. Adds 28.2-restraint-without-carveout (Warning) and 22.7-hollow-content (Suggestion) — the latter a pre-existing parity gap (shipped in Go free, missing here) — to both SKILL.md and the .mdc, including their Check IDs Reference tables.

Refs skillcheck-ay4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)