### PR TITLE
fix(parity): 4.2 inline-code exception in free rules

### DIFF
--- a/cursor-rules/skill-check.mdc
+++ b/cursor-rules/skill-check.mdc
@@ -248,6 +248,7 @@ Flag vague language that should be more specific. Terms like "multiple items" or
 
 **Exceptions** (not flagged):
 - Terms inside code blocks or blockquotes
+- Terms inside inline code spans (backticks); a backticked literal is a quoted example, not vague writing
 - Content in example/usage/pattern sections
 - Before/After and Good/Bad comparison lines
 - Terms followed by qualifiers (e.g., "some specific files")

--- a/skills/skill-check/SKILL.md
+++ b/skills/skill-check/SKILL.md
@@ -202,6 +202,7 @@ Flag vague language that should be more specific. Terms like "multiple items" or
 
 **Exceptions** (not flagged):
 - Terms inside code blocks or blockquotes
+- Terms inside inline code spans (backticks); a backticked literal is a quoted example, not vague writing
 - Content in example/usage/pattern sections
 - Before/After and correct/incorrect comparison lines
 - Terms followed by qualifiers (e.g., "some specific files")


### PR DESCRIPTION
Closes the drift I introduced: the Go/WASM 4.2 check now skips inline-code spans, so the SKILL.md + .mdc free rules must say the same. Refs skillcheck-ay4.